### PR TITLE
[FEAT] TransAction #3 uTx 추가 + makeTx 수정

### DIFF
--- a/blockchain/transactions.go
+++ b/blockchain/transactions.go
@@ -37,7 +37,7 @@ func (t *Tx) getId() {
 // TxOut에서 가져오면 되기 때문에 제외해준다.
 // 즉, 어느 TxOut에서 돈을 뽑아올지 보여주는 표지판이라고 보면 된다.
 type TxIn struct {
-	TxID  string `json:"transaction id"` // TxIn에 필요한 TxOut을 제공하는 TxID
+	TxID  string `json:"transaction id"` // uTx 검증에 사용
 	Index int    `json:"index"`
 	Owner string `json:"owner"`
 }
@@ -124,7 +124,7 @@ func makeTx(from, to string, amount int) (*Tx, error) {
 
 	total := 0
 	for _, utxOut := range BlockChain().UtxOutsByAddr(from) {
-		if total > amount {
+		if total >= amount {
 			break
 		}
 		txIns = append(txIns, &TxIn{

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -114,7 +114,7 @@ func balance(rw http.ResponseWriter, r *http.Request) {
 		utils.HandleErr(encoder.Encode(balanceMessage{address, total}))
 		return
 	}
-	utils.HandleErr(encoder.Encode(blockchain.BlockChain().TxOutsByAddr(address)))
+	utils.HandleErr(encoder.Encode(blockchain.BlockChain().UtxOutsByAddr(address)))
 }
 
 func mempool(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## FEATURE
- [x] uTxOut 구현
## TASKS
- [x] unSpentTransActionOut 개념 적용
- [x] unSpentTransActionOutByAddr 구현
- [x] makeTx 수정하기
## Others
- 기존의 TxOut은 사용됐는지 여부를 전혀 체크하지 못함
- 즉, TxIn에 넣어줄 TxOut은 사실상 마르지 않는 샘물이었음
- 그래서 사용 여부를 uTxOut을 통해서 필터링
- 블록체인에 등록된 TxId를 통해 사용 여부 검증 -- 개선 포인트: 아직 mempool에 등록된 Tx 요청은 필터링 못함
## TODO
- [ ] Mempool에 등록된 txout도 uTx 검증이 돼야 함