### PR TITLE
[FEAT][FIX] 서명 구현법 익히기 등

### DIFF
--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -53,12 +53,12 @@ func FindBlock(hash string) (*Block, error) {
 	return block, nil
 }
 
-func createBlock(prevHash string, height int) *Block {
+func createBlock(prevHash string, height, difficulty int) *Block {
 	block := Block{
 		Hash:       "",
 		PrevHash:   prevHash,
 		Height:     height,
-		Difficulty: difficulty(BlockChain()),
+		Difficulty: difficulty,
 		Nonce:      10,
 	}
 	block.mine()

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -30,7 +30,7 @@ func (b *blockchain) restore(data []byte) {
 }
 
 func (b *blockchain) AddBlock() {
-	block := createBlock(b.LatestHash, b.Height+1)
+	block := createBlock(b.LatestHash, b.Height+1, getDifficulty(b))
 	b.LatestHash = block.Hash
 	b.Height = block.Height
 	b.CurrentDifficulty = block.Difficulty
@@ -56,7 +56,7 @@ func recalculateDifficulty(b *blockchain) int {
 	return b.CurrentDifficulty
 }
 
-func difficulty(b *blockchain) int {
+func getDifficulty(b *blockchain) int {
 	if b.Height == 0 {
 		return defaultDifficulty
 	}
@@ -67,23 +67,21 @@ func difficulty(b *blockchain) int {
 }
 
 func BlockChain() *blockchain {
-	if b == nil {
-		// GetBlockChain을 통해 b 인스턴스가 실행되는 상황을 가정해보자.
-		// 그리고 수 많은 go routine 들이 GetBlockChain을 호출한다고 할 때,
-		// b 인스턴스는 한 번만 제대로 초기화 되면 된다.
-		// 그럴 때 동기 처리를 도와주는 sync 패키지를 활용한다.
-		// once.Do()는 메서드 인자에 들어온 함수를 딱 한 번만 실행하는 기능이다.e.Do()는 메서드 인자에 들어온 함수를 딱 한 번만 실행하는 기능이다.
-		once.Do(func() {
-			b = &blockchain{Height: 0}
-			checkpoint := db.LoadCheckpoint()
-			if checkpoint == nil {
-				b.AddBlock()
-				return
-			}
-			// restore b from bytes
-			b.restore(checkpoint)
-		})
-	}
+	// GetBlockChain을 통해 b 인스턴스가 실행되는 상황을 가정해보자.
+	// 그리고 수 많은 go routine 들이 GetBlockChain을 호출한다고 할 때,
+	// b 인스턴스는 한 번만 제대로 초기화 되면 된다.
+	// 그럴 때 동기 처리를 도와주는 sync 패키지를 활용한다.
+	// once.Do()는 메서드 인자에 들어온 함수를 딱 한 번만 실행하는 기능이다.e.Do()는 메서드 인자에 들어온 함수를 딱 한 번만 실행하는 기능이다.
+	once.Do(func() {
+		b = &blockchain{Height: 0}
+		checkpoint := db.LoadCheckpoint()
+		if checkpoint == nil {
+			b.AddBlock()
+			return
+		}
+		// restore b from bytes
+		b.restore(checkpoint)
+	})
 	return b
 }
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,7 @@
 package main
 
-import (
-	"github.com/YoonBaek/CryptoProject/blockchain"
-	"github.com/YoonBaek/CryptoProject/blockchain/db"
-	"github.com/YoonBaek/CryptoProject/cli"
-)
+import "github.com/YoonBaek/CryptoProject/wallet"
 
 func main() {
-	defer db.Close()
-	blockchain.BlockChain()
-	cli.Start()
+	wallet.Start()
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/YoonBaek/CryptoProject/utils"
@@ -12,5 +13,14 @@ import (
 func Start() {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	utils.HandleErr(err)
-	fmt.Println(privateKey.D)
+	targetMessage := "you are amazing"
+	hashedMessage := utils.Hash(targetMessage)
+
+	hash, err := hex.DecodeString(hashedMessage)
+	utils.HandleErr(err)
+	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash)
+	utils.HandleErr(err)
+
+	fmt.Println("R:", r)
+	fmt.Println("S:", s)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4,23 +4,31 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 
 	"github.com/YoonBaek/CryptoProject/utils"
 )
 
+const hashedMessage string = "11d2d024a8ba69cd45d1b9529016f973d0f4d78fb821c8ca67a2f8a25b09458b"
+
 func Start() {
+	// private, public key 생성
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	utils.HandleErr(err)
-	targetMessage := "you are amazing"
-	hashedMessage := utils.Hash(targetMessage)
-
+	keyAsBytes, err := x509.MarshalECPrivateKey(privateKey)
+	utils.HandleErr(err)
+	fmt.Printf("%x\n", keyAsBytes)
+	// 메시지 해싱
 	hash, err := hex.DecodeString(hashedMessage)
 	utils.HandleErr(err)
+	// 메시지 서명하기
 	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash)
 	utils.HandleErr(err)
-
-	fmt.Println("R:", r)
-	fmt.Println("S:", s)
+	signature := append(r.Bytes(), s.Bytes()...)
+	fmt.Printf("#%x\n", signature)
+	// 메세지 검증하기
+	ok := ecdsa.Verify(&privateKey.PublicKey, hash, r, s)
+	fmt.Println(ok)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,0 +1,16 @@
+package wallet
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+
+	"github.com/YoonBaek/CryptoProject/utils"
+)
+
+func Start() {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	utils.HandleErr(err)
+	fmt.Println(privateKey.D)
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2,33 +2,52 @@ package wallet
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 
 	"github.com/YoonBaek/CryptoProject/utils"
 )
 
-const hashedMessage string = "11d2d024a8ba69cd45d1b9529016f973d0f4d78fb821c8ca67a2f8a25b09458b"
+const (
+	// 저번 커밋까지 미리 뽑아 둔 정보들
+	// 얘네 들로 복구가 가능할지 지켜봄
+	privateKey    string = "30770201010420e2048ed34e6edc3249b3335e7168e6d79310ed07cc8d4b294f33d72062910363a00a06082a8648ce3d030107a144034200048e8f85542b54328d72fadc35f98adc3b3c72cd2882f3ae3e455255d54f8f0081d52891295d63d9b97776a4e31f88f009dde111b97818290e1b58d58b5a77b250"
+	hashedMessage string = "11d2d024a8ba69cd45d1b9529016f973d0f4d78fb821c8ca67a2f8a25b09458b"
+	signature     string = "c860694e014e3bd28ca0bedaf30adf20b11b75f566f9779a4d6ab1e1bb3a24e21fd9bd0df49dd3660a6c8dd85640ed0cdca3df3ec07880fb94e5756be61d5004"
+)
 
 func Start() {
-	// private, public key 생성
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	// 키 복구하기'
+	privBytes, err := hex.DecodeString(privateKey)
 	utils.HandleErr(err)
-	keyAsBytes, err := x509.MarshalECPrivateKey(privateKey)
+	restoredPrivKey, err := x509.ParseECPrivateKey(privBytes)
 	utils.HandleErr(err)
-	fmt.Printf("%x\n", keyAsBytes)
-	// 메시지 해싱
-	hash, err := hex.DecodeString(hashedMessage)
+
+	fmt.Println(restoredPrivKey)
+
+	// 공개키 복구하기
+	restoredPubKey := restoredPrivKey.PublicKey
+
+	// 서명 복구하기
+	sigBytes, err := hex.DecodeString(signature)
 	utils.HandleErr(err)
-	// 메시지 서명하기
-	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash)
+
+	mid := len(sigBytes) / 2
+	rBytes := sigBytes[:mid]
+	sBytes := sigBytes[mid:]
+
+	var restoredR, restoredS = big.Int{}, big.Int{}
+	restoredR.SetBytes(rBytes)
+	restoredS.SetBytes(sBytes)
+
+	fmt.Println(restoredR)
+	fmt.Println(restoredS)
+
+	// payload 복구하기
+	restoredMsg, err := hex.DecodeString(hashedMessage)
 	utils.HandleErr(err)
-	signature := append(r.Bytes(), s.Bytes()...)
-	fmt.Printf("#%x\n", signature)
-	// 메세지 검증하기
-	ok := ecdsa.Verify(&privateKey.PublicKey, hash, r, s)
-	fmt.Println(ok)
+	// 복구한 키로 검증해보기
+	fmt.Println(ecdsa.Verify(&restoredPubKey, restoredMsg, &restoredR, &restoredS))
 }


### PR DESCRIPTION
## FEATURE
- [x] Deadlock 문제 해결
- [x] 서명 구현법 익히기
## TASKS
- [x] Refac 후 발생한 Deadlock 문제 해결 
- [x] 메시지 해싱하기
- [x] 공개키, 비공개키, 키페어 생성 (임시)
- [x] 서명(hashed msg + 비공개키) 생성
- [x] 공개키로 서명 검증하기 (Verify)
- [x] 키, payload, 서명 복구하기
## TIL
### DeadLock 이슈
- Once.Do로 인해 Deadlock이 발생해서 수정했습니다.
정확히는 Once.Do에 적용된 핸들러 함수가 끝나지 않아 생긴 문제로,
AddBlock함수가 다시 BlockChain 함수를 호출하는 연결고리를 끊어줬습니다.
### 서명 구현법 익히기
- 키 생성: 키는 Elliptical Curve 함수의 규칙을 따라 생성합니다. PrivKey는 PubKey를 임베디드 struct로 가지면서 둘이 서로 연결되어 있습니다.
- 서명: 서명은 암호화된 난수 + 비공개키 + 페이로드로 작성할 수 있습니다.
- 검증: 작성한 서명을 공개키와 서명을 조합해 검증할 수 있습니다.

그런데 서명된 난수는 `big.Int`로 그 크기가 매우 큽니다. 따라서 비공개키, 공개키, 서명 등을 유지하기 위해서 막대한 비용이 드는 것을 피하기 위해 해싱해서 DB에 저장하고 복구할 수 있습니다. 해시는 16진수 형태의 string이기 때문에 Decode를 통해 rollback 해주고 각자 타입에 맞게 변환해서 다시 검증하면 `true`를 반환합니다.