### PR TITLE
Wallet

### DIFF
--- a/blockchain/transactions.go
+++ b/blockchain/transactions.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/YoonBaek/CryptoProject/utils"
+	"github.com/YoonBaek/CryptoProject/wallet"
 )
 
 const minerReward int = 10
@@ -54,7 +55,7 @@ type UTxOut struct {
 }
 
 func (m *mempool) AddTx(to string, amount int) error {
-	tx, err := makeTx("yoonbaek", to, amount)
+	tx, err := makeTx(wallet.Wallet().Address, to, amount)
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,7 @@ func (m *mempool) AddTx(to string, amount int) error {
 
 // make coinbase Tx and Confirm transaction standby in mempool
 func (m *mempool) Confirm() []*Tx {
-	coinbase := makeCoinbaseTx("yoonbaek")
+	coinbase := makeCoinbaseTx(wallet.Wallet().Address)
 	txs := m.Txs
 	txs = append(txs, coinbase)
 	m.Txs = nil

--- a/main.go
+++ b/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/YoonBaek/CryptoProject/wallet"
 
 func main() {
-	wallet.Start()
+	wallet.Wallet()
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"fmt"
 	"os"
 
 	"github.com/YoonBaek/CryptoProject/utils"
@@ -17,14 +18,28 @@ const (
 // follows singleton pattern
 type wallet struct {
 	privateKey *ecdsa.PrivateKey
+	Address    string
 }
 
 var w *wallet
 
-func (w *wallet) createPrivKey() {
+func (w *wallet) createKey() {
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	utils.HandleErr(err)
 	w.privateKey = privKey
+}
+
+func (w *wallet) restoreKey() {
+	keyAsBytes, err := os.ReadFile(fileName)
+	utils.HandleErr(err)
+	restoredKey, err := x509.ParseECPrivateKey(keyAsBytes)
+	utils.HandleErr(err)
+	w.privateKey = restoredKey
+}
+
+func (w *wallet) getAddress(pubKey *ecdsa.PublicKey) {
+	address := append(pubKey.X.Bytes(), pubKey.Y.Bytes()...)
+	w.Address = fmt.Sprintf("%x", address)
 }
 
 func Wallet() *wallet {
@@ -32,13 +47,14 @@ func Wallet() *wallet {
 	if w == nil {
 		w = &wallet{}
 		// 해당 지갑 정보가 있는지 확인하기
-		if hasWallet() {
-			// 있다면 파일로부터 불러오기
-			return w
+		switch hasWallet() {
+		case true: // 있다면 파일로부터 불러오기
+			w.restoreKey()
+		default: // 없다면 비공개키를 생성해 주고 파일에 저장
+			w.createKey()
+			persistKey(w.privateKey)
 		}
-		// 없다면 비공개키를 생성해 주고 파일에 저장
-		w.createPrivKey()
-		persistKey(w.privateKey)
+		w.getAddress(&w.privateKey.PublicKey)
 	}
 	return w
 }


### PR DESCRIPTION
## FEATURE
- [x] Wallet 구현하기
## TASKS
- [x] Singleton 패턴 wallet 인스턴스 생성
- [x] 신규 wallet 생성 및 저장
- [x] 지갑 주소 구현
- [x] wallet 복구 및 transaction에 wallet 적용
- [x] 서명 (signature) 구현
- [x] 검증 (verifying) 구현
## TIL
- Wallet은 Key(pv + pub)와 주소로 구성되어 있다.
- byte 형태로 지갑 정보를 저장하고 다시 restore할 수 있다.
- signature의 r과 s, 그리고 pubkey의 x,y는 모두 bigInt이기 때문에 byte형태로 만들어 파일로 저장해준다.
- address는 Pubkey의 16진수 해시형태이다.
## Somethings buggin me
- 아직 `Sign`함수를 연동한 건 아니기 때문에 payload가 16진수 해시인지에 따라 첫번째 라인을 삭제하거나 유지해야 한다.